### PR TITLE
Support nested modules by relativizing identifiers

### DIFF
--- a/ppx/ppx_interact.ml
+++ b/ppx/ppx_interact.ml
@@ -34,6 +34,20 @@ let var_names_of =
       match p.ppat_desc with Ppat_var { txt; _ } -> txt :: acc | _ -> acc
   end
 
+let unflatten_ident = function
+  | x :: l -> List.fold_left (fun acc s -> Ldot (acc, s)) (Lident x) l
+  | _ -> failwith "ident must contain at least one segment"
+
+let rec remove_common a b =
+  match (a, b) with
+  | x :: a', y :: b' when x = y -> remove_common a' b'
+  | _ -> (a, b)
+
+let relativize_ident ident ctx =
+  let flat = Longident.flatten_exn ident in
+  let flat', _ = remove_common flat (List.rev ctx) in
+  unflatten_ident flat'
+
 let traverse () =
   object
     inherit [env] Ast_traverse.fold_map as super
@@ -96,17 +110,11 @@ let traverse () =
       | Pexp_extension ({ txt = s; _ }, payload) when String.equal s "interact"
         ->
         let loc = e.pexp_loc in
-        let elt (name, original_ctx, ident) =
+        let elt (name, _original_ctx, ident) =
           let s = Exp.constant ~loc (Const.string ~loc name) in
           let id =
             Exp.ident ~loc
-              {
-                txt =
-                  (* check at the use site if we're still in that module, if so don't qualify *)
-                  (if env.module_context != original_ctx then ident
-                  else Lident name);
-                loc;
-              }
+              { txt = relativize_ident ident env.module_context; loc }
           in
           [%expr V ([%e s], [%e id])]
         in

--- a/test/pp.expected
+++ b/test/pp.expected
@@ -1,29 +1,41 @@
-module A = struct let one = 1
-                  module C = struct let nested = 1 end end
+module A =
+  struct
+    let one = 1
+    module C = struct let nested = 1 end
+    let foo a =
+      let b =
+        Ppx_interact_runtime.view_file 31 "test.ml";
+        Ppx_interact_runtime.interact ~unit:__MODULE__ ~loc:__POS__
+          ~values:[V ("a", a); V ("nested", C.nested); V ("one", one)] () in
+      a + b
+  end
 let a () = let e = 1 in 2
 let () =
   let _ =
     let d = 3 in
-    Ppx_interact_runtime.view_file 38 "test.ml";
+    Ppx_interact_runtime.view_file 42 "test.ml";
     Ppx_interact_runtime.interact ~unit:__MODULE__ ~loc:__POS__
       ~values:[V ("d", d);
               V ("a", a);
+              V ("foo", A.foo);
               V ("nested", A.C.nested);
               V ("one", A.one)] () in
   let b = 2 in
   let f a =
-    Ppx_interact_runtime.view_file 41 "test.ml";
+    Ppx_interact_runtime.view_file 45 "test.ml";
     Ppx_interact_runtime.interact ~unit:__MODULE__ ~loc:__POS__
       ~values:[V ("a", a);
               V ("b", b);
               V ("a", a);
+              V ("foo", A.foo);
               V ("nested", A.C.nested);
               V ("one", A.one)] () in
-  (Ppx_interact_runtime.view_file 42 "test.ml";
+  (Ppx_interact_runtime.view_file 46 "test.ml";
    Ppx_interact_runtime.interact ~unit:__MODULE__ ~loc:__POS__
      ~values:[V ("f", f);
              V ("b", b);
              V ("a", a);
+             V ("foo", A.foo);
              V ("nested", A.C.nested);
              V ("one", A.one)] ());
   f 2
@@ -31,10 +43,11 @@ module B =
   struct
     let inside = 2
     let () =
-      Ppx_interact_runtime.view_file 47 "test.ml";
+      Ppx_interact_runtime.view_file 51 "test.ml";
       Ppx_interact_runtime.interact ~unit:__MODULE__ ~loc:__POS__
         ~values:[V ("inside", inside);
                 V ("a", a);
+                V ("foo", A.foo);
                 V ("nested", A.C.nested);
                 V ("one", A.one)] ()
   end

--- a/test/test.ml
+++ b/test/test.ml
@@ -26,6 +26,10 @@ module A = struct
   module C = struct
     let nested = 1
   end
+
+  let foo a =
+    let b = [%interact] in
+    a + b
 end
 
 let a () =


### PR DESCRIPTION
Hello!

I recently tried to use `ppx_interact` on a module containing a nested module similar to the following:

```ocaml
module A = struct
  let one = 1

  module C = struct
    let nested = 1
  end

  let foo a =
    let b = [%interact] in
    a + b
end
```

Compiling the code generated by `ppx_interact` for this module results in an error stating that the `A` module is unbound.

In the context of `A.foo`, `ppx_interact` would generate a reference to `nested` with the fully qualified identifier `A.C.nested`, which seems incorrect.

This changeset relativizes these identifiers so that the common segment between the identifier and the current context is removed. The previous reference to `A.C.nested` would become `C.nested`.

I don't have much OCaml experience, so please correct me if I've missed something!